### PR TITLE
Add JSON day data and template support

### DIFF
--- a/bin/mkdirp-journal-day.mjs
+++ b/bin/mkdirp-journal-day.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env zx
+
+const day = argv._[1]
+if (!day) {
+  console.error('Usage: mkdirp-journal-day.mjs YYYY-MM-DD')
+  process.exit(1)
+}
+
+const [y, m, d] = day.split('-')
+const dayPath = `./content/j/${y}/${m}/${d}`
+await $`mkdir -p ${dayPath}`
+
+const indexContent = `---
+title: "${day}"
+date: ${day}T00:00:00Z
+tags: []
+---
+
+<!--more-->
+`
+await $`echo ${indexContent} > ${dayPath}/_index.md`
+
+// create placeholder JSON data files
+await $`echo '{}' > ${dayPath}/run.json`
+await $`echo '{}' > ${dayPath}/nomie.json`
+await $`echo '{}' > ${dayPath}/swarm.json`

--- a/content/j/2025/06/01/_index.md
+++ b/content/j/2025/06/01/_index.md
@@ -1,0 +1,9 @@
+---
+title: "2025-06-01"
+date: 2025-06-01T00:00:00Z
+tags: []
+---
+
+<!--more-->
+
+First journal entry.

--- a/content/j/2025/06/01/nomie.json
+++ b/content/j/2025/06/01/nomie.json
@@ -1,0 +1,3 @@
+{
+  "overall_mood": 4
+}

--- a/content/j/2025/06/01/run.json
+++ b/content/j/2025/06/01/run.json
@@ -1,0 +1,4 @@
+{
+  "distance_miles": 5,
+  "duration_minutes": 40
+}

--- a/content/j/2025/06/01/swarm.json
+++ b/content/j/2025/06/01/swarm.json
@@ -1,0 +1,8 @@
+{
+  "checkins": [
+    {
+      "venue": "Coffee Shop",
+      "time": "2025-06-01T09:00:00Z"
+    }
+  ]
+}

--- a/content/j/2025/06/_index.md
+++ b/content/j/2025/06/_index.md
@@ -1,0 +1,8 @@
+---
+title: "June 2025"
+date: 2025-06-01
+cascade:
+  month: 6
+---
+
+Entries from June 2025.

--- a/content/j/2025/_index.md
+++ b/content/j/2025/_index.md
@@ -1,0 +1,8 @@
+---
+title: "2025 Journal"
+date: 2025-01-01
+cascade:
+  year: 2025
+---
+
+Journal entries for 2025.

--- a/content/j/_index.md
+++ b/content/j/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Journal"
+date: 2025-06-01
+---
+
+Personal journal entries organized by date.

--- a/layouts/j/list.html
+++ b/layouts/j/list.html
@@ -1,0 +1,39 @@
+{{ define "main" }}
+<h2>{{ .Title }}</h2>
+<p>
+  {{ partial "breadcrumb.html" . }}
+  {{ partial "tag-list.html" . }}
+</p>
+
+<div>{{ .Content }}</div>
+<p>Total entries: {{ len .RegularPagesRecursive }}</p>
+
+{{ $jsonFiles := .Resources.Match "*.json" }}
+{{ if $jsonFiles }}
+<h3>Data Files</h3>
+<ul>
+  {{ range $jsonFiles }}
+  {{ $data := . | transform.Unmarshal }}
+  <li>{{ .Name }}: <pre>{{ $data | jsonify }}</pre></li>
+  {{ end }}
+</ul>
+{{ end }}
+
+{{ if .Sections }}
+<h3>Subsections</h3>
+<ul>
+  {{ range .Sections }}
+  <li><a href="{{ .RelPermalink }}">{{ .Title }}</a> ({{ len .RegularPagesRecursive }} entries)</li>
+  {{ end }}
+</ul>
+{{ end }}
+
+{{ if .RegularPages }}
+<h3>Entries</h3>
+<ul>
+  {{ range .RegularPages }}
+  <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+  {{ end }}
+</ul>
+{{ end }}
+{{ end }}


### PR DESCRIPTION
## Summary
- replace sample journal day markdown with JSON data
- load JSON data files in the journal list template
- generate placeholder JSON files when creating a journal day

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_686370bb7fc48323bc8005f82c73e42c