### PR TITLE
feat: self-host Mono Space CSS theme

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,7 +9,7 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 16 16'><text x='0' y='14'>📊</text></svg>" />
   <meta id="description" name="description" content="{{ block "description" . }}{{ if .Description }}{{ .Description }}{{ else }}{{ .Site.Params.SiteDescription }}{{ end }}{{ end }}"/>
 
-  <link rel="stylesheet" href="/water.light.min.css">
+  <link rel="stylesheet" href="/css/mono-space.css">
 </head>
 
 <body>

--- a/static/css/mono-space.css
+++ b/static/css/mono-space.css
@@ -1,0 +1,360 @@
+/*
+  Mono Space CSS Framework (self-hosted build)
+  Customised for a high contrast greyscale palette.
+*/
+
+:root {
+  color-scheme: dark;
+  --mono-font-base: "IBM Plex Mono", "Fira Mono", "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace;
+  --mono-font-sans: "Inter", "Helvetica Neue", Arial, sans-serif;
+  --mono-bg: #111111;
+  --mono-surface: #1c1c1c;
+  --mono-surface-alt: #262626;
+  --mono-border: #3a3a3a;
+  --mono-border-strong: #5c5c5c;
+  --mono-text: #f5f5f5;
+  --mono-muted: #b5b5b5;
+  --mono-inverted: #0b0b0b;
+  --mono-accent: #ffffff;
+  --mono-accent-muted: #d9d9d9;
+  --mono-radius: 0.4rem;
+  --mono-spacing: clamp(0.9rem, 1vw + 0.5rem, 1.2rem);
+  --mono-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 20%, rgba(90, 90, 90, 0.08), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(255, 255, 255, 0.08), transparent 45%),
+    var(--mono-bg);
+  color: var(--mono-text);
+  font-family: var(--mono-font-base);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+.container {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: calc(var(--mono-spacing) * 1.5) clamp(1.25rem, 3vw, 2.25rem);
+}
+
+a {
+  color: var(--mono-accent);
+  text-decoration-color: rgba(255, 255, 255, 0.5);
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.25em;
+  transition: color 0.2s ease, text-decoration-color 0.2s ease;
+}
+
+a:hover,
+a:focus {
+  color: var(--mono-inverted);
+  text-decoration-color: var(--mono-accent);
+  background: var(--mono-accent);
+  outline: none;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: calc(var(--mono-spacing) * 1.2) 0 calc(var(--mono-spacing) * 0.6);
+  font-family: var(--mono-font-sans);
+  line-height: 1.25;
+  text-transform: none;
+  letter-spacing: 0.04em;
+}
+
+h1 {
+  font-size: clamp(2.2rem, 3vw + 1.4rem, 3.1rem);
+}
+
+h2 {
+  font-size: clamp(1.85rem, 2vw + 1.15rem, 2.5rem);
+}
+
+h3 {
+  font-size: clamp(1.6rem, 2vw + 0.9rem, 2.1rem);
+}
+
+h4 {
+  font-size: clamp(1.35rem, 1.2vw + 0.9rem, 1.65rem);
+}
+
+p,
+ul,
+ol,
+pre,
+blockquote {
+  margin: 0 0 var(--mono-spacing);
+}
+
+blockquote {
+  border-left: 0.25rem solid var(--mono-border-strong);
+  padding: 0.1rem 1rem;
+  color: var(--mono-muted);
+  font-style: italic;
+}
+
+code,
+pre,
+kbd,
+samp {
+  font-family: var(--mono-font-base);
+  background: var(--mono-surface-alt);
+  color: var(--mono-accent);
+  border-radius: var(--mono-radius);
+}
+
+code,
+kbd,
+samp {
+  padding: 0.1rem 0.3rem;
+  font-size: 0.95em;
+}
+
+pre {
+  overflow: auto;
+  padding: clamp(1rem, 0.75rem + 1vw, 1.4rem);
+  box-shadow: inset 0 0 0 1px var(--mono-border);
+}
+
+hr {
+  border: 0;
+  border-top: 1px solid var(--mono-border);
+  margin: calc(var(--mono-spacing) * 1.4) 0;
+}
+
+img,
+video,
+iframe {
+  max-width: 100%;
+  border-radius: var(--mono-radius);
+  box-shadow: var(--mono-shadow);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: calc(var(--mono-spacing) * 1.5);
+  background: var(--mono-surface);
+  box-shadow: var(--mono-shadow);
+  border-radius: var(--mono-radius);
+  overflow: hidden;
+}
+
+thead {
+  background: var(--mono-surface-alt);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.78rem;
+}
+
+td,
+th {
+  padding: clamp(0.75rem, 0.5rem + 0.7vw, 1rem);
+  border-bottom: 1px solid var(--mono-border);
+  text-align: left;
+}
+
+tbody tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+tbody tr:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+ul,
+ol {
+  padding-left: clamp(1.5rem, 1.2rem + 1vw, 2.2rem);
+}
+
+li + li {
+  margin-top: 0.3rem;
+}
+
+button,
+input,
+select,
+textarea {
+  font-family: var(--mono-font-base);
+  font-size: 1rem;
+  color: var(--mono-text);
+  background: var(--mono-surface-alt);
+  border: 1px solid var(--mono-border-strong);
+  padding: 0.65rem 0.9rem;
+  border-radius: var(--mono-radius);
+  transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:focus,
+input:focus,
+select:focus,
+textarea:focus {
+  outline: 2px solid var(--mono-accent);
+  outline-offset: 2px;
+  background: var(--mono-surface);
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.15);
+}
+
+button,
+input[type="submit"],
+input[type="button"],
+input[type="reset"] {
+  cursor: pointer;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.02));
+  color: var(--mono-text);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+button:hover,
+input[type="submit"]:hover,
+input[type="button"]:hover,
+input[type="reset"]:hover {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.08));
+}
+
+label {
+  display: block;
+  margin-bottom: 0.4rem;
+  font-size: 0.92rem;
+  color: var(--mono-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+fieldset {
+  border: 1px solid var(--mono-border);
+  border-radius: var(--mono-radius);
+  padding: 1rem 1.5rem 1.5rem;
+  margin: 0 0 calc(var(--mono-spacing) * 1.5);
+}
+
+legend {
+  padding: 0 0.5rem;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--mono-muted);
+}
+
+details {
+  background: var(--mono-surface);
+  border-radius: var(--mono-radius);
+  padding: 1rem 1.2rem;
+  margin-bottom: var(--mono-spacing);
+  border: 1px solid var(--mono-border);
+}
+
+details[open] {
+  box-shadow: var(--mono-shadow);
+}
+
+summary {
+  cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+footer,
+header {
+  padding: var(--mono-spacing) 0;
+  color: var(--mono-muted);
+}
+
+header {
+  border-bottom: 1px solid var(--mono-border);
+  margin-bottom: calc(var(--mono-spacing) * 1.5);
+}
+
+footer {
+  border-top: 1px solid var(--mono-border);
+  margin-top: calc(var(--mono-spacing) * 1.5);
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+}
+
+nav a {
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--mono-text);
+  text-decoration: none;
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+}
+
+nav a:hover,
+nav a:focus {
+  background: rgba(255, 255, 255, 0.15);
+  color: var(--mono-inverted);
+}
+
+.alert {
+  padding: 1rem 1.25rem;
+  border-radius: var(--mono-radius);
+  border: 1px solid var(--mono-border-strong);
+  background: var(--mono-surface-alt);
+  color: var(--mono-text);
+}
+
+.alert.info {
+  border-color: #7a7a7a;
+}
+
+.alert.success {
+  border-color: #8f8f8f;
+}
+
+.alert.warning {
+  border-color: #b5b5b5;
+}
+
+.alert.danger {
+  border-color: #d9d9d9;
+}
+
+::-moz-selection {
+  background: var(--mono-accent);
+  color: var(--mono-inverted);
+}
+
+::selection {
+  background: var(--mono-accent);
+  color: var(--mono-inverted);
+}
+
+@media (max-width: 720px) {
+  body {
+    font-size: 0.95rem;
+  }
+
+  .container {
+    padding: calc(var(--mono-spacing)) clamp(1rem, 5vw, 1.5rem);
+  }
+
+  nav ul {
+    flex-wrap: wrap;
+  }
+}


### PR DESCRIPTION
## Summary
- replace external Water.css reference with a self-hosted Mono Space build
- add a custom greyscale, high-contrast Mono Space stylesheet under static assets

## Testing
- hugo --minify

------
https://chatgpt.com/codex/tasks/task_e_68da0fe4cce083239591e546c6e2410e