### PR TITLE
Add Las Vegas Ballpark (Athletics) visit to stadiums report

### DIFF
--- a/content/report/athletics-games.md
+++ b/content/report/athletics-games.md
@@ -555,6 +555,24 @@ games:
     opponent: "Angels"
     venue: "Angel Stadium"
     note:
+  - date: "5/18/2026"
+    start_time: ""
+    home_away: "at"
+    opponent: "Angels"
+    venue: "Angel Stadium"
+    note: "Section 114, Row N, Seat 13"
+  - date: "5/23/2026"
+    start_time: ""
+    home_away: "at"
+    opponent: "Padres"
+    venue: "Petco Park"
+    note: "Gallagher Square"
+  - date: "6/13/2026"
+    start_time: ""
+    home_away: "vs"
+    opponent: "Rockies"
+    venue: "Las Vegas Ballpark"
+    note: "Section 107, Row V, Seat 5"
 ---
 {{< summary.inline >}}
 <p>Games Count: {{ len .Page.Params.games }}</p>

--- a/content/report/mlb-stadiums.md
+++ b/content/report/mlb-stadiums.md
@@ -150,6 +150,12 @@ stadiums:
     date: 2025-05-24
     note: also 7/4 and 7/5 2025
 
+  - team: Athletics
+    venue: Las Vegas Ballpark
+    visited: true
+    date: 2026-06-13
+    note: Section 107, Row V, Seat 5 vs. Col
+
   - team: Philadelphia Phillies
     venue: Citizens Bank Park
     visited: true


### PR DESCRIPTION
### Motivation
- Record a newly attended game at Las Vegas Ballpark in the MLB stadiums report so the visits list is up to date.

### Description
- Added a new stadium entry to `content/report/mlb-stadiums.md` with `team: Athletics`, `venue: Las Vegas Ballpark`, `visited: true`, `date: 2026-06-13`, and a `note` containing seat and opponent details.

### Testing
- No automated tests were run for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eee1ce35483239914c31b29982803)