### PR TITLE
Convert birthday workouts to structured data + inline shortcode

### DIFF
--- a/content/report/birthday-workouts.md
+++ b/content/report/birthday-workouts.md
@@ -2,39 +2,142 @@
 title: "Birthday Workouts"
 date: 2019-07-20T00:17:09-08:00
 tags: ["meta", "running", "birthday"]
+workouts:
+- year: 2026
+  location: Beverlywood, Los Angeles, CA
+  miles: 7.28
+  duration: "58:04"
+  climb_ft: 495
+  garmin_id: 23511129601
+- year: 2025
+  note: "No workout. Push-ups only; see nomie"
+- year: 2024
+  location: Griffith Park, Los Angeles, CA
+  miles: 10.35
+  duration: "1:37:12"
+  climb_ft: 1829
+  garmin_id: 16291458055
+- year: 2023
+  location: Westridge Canyon, Los Angeles, CA
+  miles: 6.27
+  duration: "1:01:54"
+  climb_ft: 1483
+  garmin_id: 11508446457
+- year: 2022
+  location: Los Angeles, CA
+  miles: 6.22
+  duration: "53:01"
+  garmin_id: 9158446101
+- year: 2021
+  note: "No workout"
+- year: 2020
+  note: "Peloton ride"
+  links:
+  - label: 45 minute intervals and arms
+    url: https://members.onepeloton.com/profile/workouts/268de23c48c840adbf64bb1eba03ccc6
+  - label: 5 minute cool down
+    url: https://members.onepeloton.com/profile/workouts/e74cc54760a54d79b9fd275d40484894
+- year: 2019
+  note: "no workout"
+- year: 2018
+  location: Los Angeles, CA
+  miles: 4.0
+  duration: "36:30"
+  garmin_id: 2832933782
+- year: 2017
+  location: Occidental, CA
+  miles: 5.0
+  duration: "43:44"
+  garmin_id: 1840565277
+- year: 2016
+  note: "no run"
+- year: 2015
+  note: "no run"
+- year: 2014
+  location: Marina Del Rey, CA
+  miles: 4.0
+  duration: "41:00"
+  garmin_id: 543552603
+- year: 2013
+  note: "no run"
+- year: 2012
+  location: Marina Del Rey, CA
+  miles: 6.0
+  duration: "58:00"
+  garmin_id: 203353913
+- year: 2011
+  location: Sherman Oaks, CA
+  miles: 3.0
+  duration: "25:57"
+  garmin_id: 97458436
+- year: 2010
+  location: Santa Monica, CA
+  note: gretna green
+  miles: 3.01
+  duration: "26:43"
+  garmin_id: 39809657
+- year: 2009
+  location: Sherman Oaks, CA
+  miles: 5.0
+  duration: "35:02"
+- year: 2008
+  location: Sherman Oaks, CA
+  note: 50 min 2500 yds swim
+- year: 2007
+  location: Montclair, CA
+  note: swim 30:02
+- year: 2006
+  note: "bike to school. Lift arms. Bike home. Stretch roll. Ice left leg."
+- year: 2005
+  note: "AM - Run 20:31 meeks bay desolation trail. PM - Core 3x100-20-100 + 15 extra pushups."
+- year: 2004
+  note: open water swim in lake tahoe
+- year: 2003
+  note: double. Meeks bay trail Tahoe. 64 min 7am. 30 minute 3pm
+- year: 2002
+  note: "no run"
+- year: 2001
+  note: "no run, traveling to sf marathon relay on July 8."
+- year: 2000
+  note: "?"
+- year: 1999
+  note: "?"
 ---
 
 {{< summary.inline >}}
-<p>Count: 28</p>
+<p>Count: {{ len .Page.Params.workouts }}</p>
 {{< /summary.inline >}}
 
 <!--more-->
 
-- 2026 - Beverlywood, Los Angeles, CA - 7.28 mi - 58:04 (495 ft climb) - [garmin](https://connect.garmin.com/modern/activity/23511129601)
-- 2025 - No workout. Push-ups only; see nomie
-- 2024 - Griffith Park, Los Angeles, CA - 10.35 mi - 1:37:12 (1,829 ft climb) - [garmin](https://connect.garmin.com/modern/activity/16291458055)
-- 2023 - Westridge Canyon, Los Angeles, CA - 6.27 mi - 1:01:54 (1,483 ft climb) - [garmin](https://connect.garmin.com/modern/activity/11508446457)
-- 2022 - Los Angeles, CA - 6.22 mi - 53:01 - [garmin](https://connect.garmin.com/modern/activity/9158446101)
-- 2021 - No workout
-- 2020 - Peloton ride: [45 minute intervals and arms](https://members.onepeloton.com/profile/workouts/268de23c48c840adbf64bb1eba03ccc6), [5 minute cool down](https://members.onepeloton.com/profile/workouts/e74cc54760a54d79b9fd275d40484894)
-- 2019 - no workout
-- 2018 - Los Angeles, CA - 4.0 mi - 36:30 - [link](https://connect.garmin.com/modern/activity/2832933782)
-- 2017 - Occidental, CA - 5.0 mi - 43:44 - [link](https://connect.garmin.com/modern/activity/1840565277)
-- 2016 - no run
-- 2015 - no run
-- 2014 - Marina Del Rey, CA. 4.0 mi - 41:00 - [link](https://connect.garmin.com/modern/activity/543552603)
-- 2013 - no run
-- 2012 - Marina Del Rey, CA. 6.0 mi - 58:00 - [link](https://connect.garmin.com/modern/activity/203353913)
-- 2011 - Sherman Oaks, CA. 3.0 mi - 25:57 - [link](https://connect.garmin.com/modern/activity/97458436)
-- 2010 - Santa Monica, CA. gretna green - 3.01 mi - 26:43 - [link](https://connect.garmin.com/modern/activity/39809657)
-- 2009 - Sherman Oaks, CA - 5.0 mi - 35:02
-- 2008 - Sherman Oaks, CA - 50 min 2500 yds swim
-- 2007 - Montclair, CA - swim 30:02
-- 2006 - bike to school. Lift arms. Bike home. Stretch roll. Ice left leg.
-- 2005 - AM - Run 20:31 meeks bay desolation trail. PM - Core 3x100-20-100 + 15 extra pushups.
-- 2004 - open water swim in lake tahoe
-- 2003 - double. Meeks bay trail Tahoe. 64 min 7am. 30 minute 3pm
-- 2002 - no run
-- 2001 - no run, traveling to sf marathon relay on July 8.
-- 2000 - ?
-- 1999 - ?
+{{< detail.inline >}}
+
+<ul>
+{{ range .Page.Params.workouts }}
+  {{ $line := printf "%d" .year }}
+  {{ if .location }}{{ $line = printf "%s - %s" $line .location }}{{ end }}
+  {{ if .note }}{{ $line = printf "%s - %s" $line .note }}{{ end }}
+  {{ if .miles }}{{ $line = printf "%s - %v mi" $line .miles }}{{ end }}
+  {{ if .duration }}
+    {{ if .climb_ft }}
+      {{ $line = printf "%s - %s (%s ft climb)" $line .duration (lang.FormatNumber 0 .climb_ft) }}
+    {{ else }}
+      {{ $line = printf "%s - %s" $line .duration }}
+    {{ end }}
+  {{ end }}
+  {{ if .garmin_id }}
+    {{ $line = printf `%s - <a href="https://connect.garmin.com/modern/activity/%v">garmin</a>` $line .garmin_id }}
+  {{ end }}
+  {{ if .links }}
+    {{ $linkHtml := "" }}
+    {{ range $i, $l := .links }}
+      {{ if $i }}{{ $linkHtml = printf "%s, " $linkHtml }}{{ end }}
+      {{ $linkHtml = printf `%s<a href="%s">%s</a>` $linkHtml $l.url $l.label }}
+    {{ end }}
+    {{ $line = printf "%s - %s" $line $linkHtml }}
+  {{ end }}
+  <li>{{ $line | safeHTML }}</li>
+{{ end }}
+</ul>
+
+{{< /detail.inline >}}


### PR DESCRIPTION
## Summary
- Moves `content/report/birthday-workouts.md` from a hand-written markdown list to a `workouts[]` front-matter array, rendered via `summary.inline`/`detail.inline` shortcodes — same pattern as the BBT running report.
- Fields per entry: `year`, `location`, `note`, `miles`, `duration`, `climb_ft`, `garmin_id`, and `links` (for the 2020 Peloton entry with two named links).
- The "Count" summary now derives from `len(workouts)` instead of being hand-maintained.
- Minor normalizations: all Garmin links now say "garmin" (a few older entries said "link"); whole-number miles render as `4 mi` instead of `4.0 mi`.

## Test plan
- [x] `hugo` build succeeds
- [x] Verified all 28 rendered `<li>` entries match the original list content
- [x] Verified the summary count auto-updates to 28

🤖 Generated with [Claude Code](https://claude.com/claude-code)