### PR TITLE
Link USA note to US States Running report

### DIFF
--- a/content/report/adhoc/international-running.md
+++ b/content/report/adhoc/international-running.md
@@ -5,7 +5,7 @@ tags: ["running", "checklist", "travel", "meta"]
 by_country:
   - name: United States
     date: 1998-05-17
-    notes: Home country. See US States Running for detail.
+    notes: 'Home country. See <a href="/report/adhoc/us-states-running/">US States Running</a> for detail.'
   - name: France
     date: 2023-01-29
     notes: Paris
@@ -68,7 +68,7 @@ by_country:
     <tr>
       <td>{{ $country.name }}</td>
       <td>{{ $country.date }}</td>
-      <td>{{ $country.notes | default "" }}</td>
+      <td>{{ $country.notes | default "" | safeHTML }}</td>
     </tr>
   {{ end }}
 


### PR DESCRIPTION
Renders the note as HTML via safeHTML, matching the pattern already
used in birthday-workouts.md for inline links.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019d3tUuSt7jYvPSUnDxqoKn